### PR TITLE
Added variables for selection the MM layer with double readout

### DIFF
--- a/apv.C
+++ b/apv.C
@@ -70,7 +70,7 @@ map<unsigned long, apv::doubleReadoutHits> apv::GetCentralHits2ROnly(unsigned lo
       
 
       hits.push_back({layer, strip, maxQ, maxTime, raw_q->at(j)});      
-      if(layer == 2 && strip > 153 && strip < 210)
+      if(layer == layerDoubleReadout && strip > 153 && strip < 210)
         hitsL2.push_back({layer, strip, maxQ, maxTime, raw_q->at(j)});
       hitsPerLayer.at(layer).emplace(strip, maxQ);
     }

--- a/apv.h
+++ b/apv.h
@@ -132,6 +132,7 @@ public :
 
   unsigned int nAPVLayers = 5;
   unsigned int pulserAPV = 10; // 2
+  unsigned int layerDoubleReadout = 0; // 2
 };
 
 tuple<double,double,double> apv::getHitsForTrack(apvTrack track){

--- a/evBuilder.C
+++ b/evBuilder.C
@@ -262,7 +262,7 @@ map<unsigned long, analysisGeneral::mm2CenterHitParameters> evBuilder::GetCentra
 
         // if(ffpdo < pdoThr) continue;
 
-        if(ffchD == 4) // All MM channels
+        if(ffchD == mmDoubleReadout) // All MM channels
         { 
           if (fabs(trigTime - fft) < 500)
           {
@@ -303,7 +303,6 @@ map<unsigned long, analysisGeneral::mm2CenterHitParameters> evBuilder::GetCentra
       for(auto h: MmCluster){
         hit.hitsX.emplace(h.channel, h.pdo);
       }
-
     }
 
     double syncTimeDiff = syncTime - lastSyncTime;
@@ -403,7 +402,7 @@ void evBuilder::Loop(unsigned long n)
         strawMin = s.second.second;
       if(strawMax < 0 || strawMax < s.second.second)
         strawMax = s.second.second;
-    } else if(s.second.first == 4){
+    } else if(s.second.first == mmDoubleReadout){
       if(mmMin < 0 || mmMin > s.second.second)
         mmMin = s.second.second;
       if(mmMax < 0 || mmMax < s.second.second)
@@ -655,9 +654,9 @@ void evBuilder::Loop(unsigned long n)
             // double fft = getTimeByHand(ffbcid, fftdo, 110, 160); //'hand' limits
             double fft = getTime(ffch, ffbcid, fftdo, ffpdoUC); // 'auto' limits
 
-            if(ffchD != 4 && ffpdo < pdoThr) continue; // only for non-mm
+            if(ffchD != mmDoubleReadout && ffpdo < pdoThr) continue; // only for non-mm
 
-            if(ffchD == 4) // All MM channels
+            if(ffchD == mmDoubleReadout) // All MM channels
             { 
               if (fabs(t_srtraw - fft) < 500)
               {
@@ -799,7 +798,7 @@ void evBuilder::Loop(unsigned long n)
 
             if(ffpdo < pdoThr) continue;
 
-            if(ffchD == 4) // All MM channels
+            if(ffchD == mmDoubleReadout) // All MM channels
             { 
               if (fabs(t_srtraw - fft) < 500)
               {

--- a/evBuilder.h
+++ b/evBuilder.h
@@ -45,6 +45,8 @@ public :
    vector<mmHit> MmCluster;
    tuple<double, double, double> getClusterParameters(double t_srtraw, double minT_straw_mm, int workType = 0);
   long long findFirstGoodPulser(unsigned long long fromSec = 0, unsigned long long toSec = 0);
+
+  unsigned int mmDoubleReadout = 2; // 4  
 };
 
 evBuilder::evBuilder(TString filename, TString runType_, TString mapFile_) : vmm(filename, runType_, mapFile_)


### PR DESCRIPTION
Corrected mm selection in evBuilder and work with double readout layer in GetCentralHits2ROnly function.
It is important to re-download updated map files for mu2e
